### PR TITLE
[security] Update Debian stable and oldstable (apt CVE-2016-1252)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -3,42 +3,42 @@ Maintainers: Tianon Gravi <tianon@debian.org> (@tianon),
 GitRepo: https://github.com/tianon/docker-brew-debian.git
 
 # commits: (master..dist-stable)
-#  - 2c836bc 2016-11-04 debootstraps
+#  - d220bea 2016-12-13 debootstraps
 
 # commits: (master..dist-unstable)
 #  - 9b1dd4b 2016-11-04 debootstraps
 
 # commits: (master..dist-oldstable)
-#  - 1626bb6 2016-11-04 debootstraps
+#  - a7561be 2016-12-13 debootstraps
 
 Tags: 8.6, 8, jessie, latest
 GitFetch: refs/heads/dist-stable
-GitCommit: 2c836bc53feb12f70a07dacaa6256d4d66624f38
+GitCommit: d220bea42308935d3bee1b40701f39e8c0d69860
 Directory: jessie
 
 Tags: jessie-slim
 GitFetch: refs/heads/dist-stable
-GitCommit: 2c836bc53feb12f70a07dacaa6256d4d66624f38
+GitCommit: d220bea42308935d3bee1b40701f39e8c0d69860
 Directory: jessie/slim
 
 Tags: jessie-backports
 GitFetch: refs/heads/dist-stable
-GitCommit: 2c836bc53feb12f70a07dacaa6256d4d66624f38
+GitCommit: d220bea42308935d3bee1b40701f39e8c0d69860
 Directory: jessie/backports
 
 Tags: oldstable
 GitFetch: refs/heads/dist-oldstable
-GitCommit: 1626bb6698f1cab6e7529a4238717270699a8246
+GitCommit: a7561bee7a4bbc2e5f7ea6b8a7377d8abe6eb2a6
 Directory: oldstable
 
 Tags: oldstable-slim
 GitFetch: refs/heads/dist-oldstable
-GitCommit: 1626bb6698f1cab6e7529a4238717270699a8246
+GitCommit: a7561bee7a4bbc2e5f7ea6b8a7377d8abe6eb2a6
 Directory: oldstable/slim
 
 Tags: oldstable-backports
 GitFetch: refs/heads/dist-oldstable
-GitCommit: 1626bb6698f1cab6e7529a4238717270699a8246
+GitCommit: a7561bee7a4bbc2e5f7ea6b8a7377d8abe6eb2a6
 Directory: oldstable/backports
 
 Tags: sid
@@ -53,17 +53,17 @@ Directory: sid/slim
 
 Tags: stable
 GitFetch: refs/heads/dist-stable
-GitCommit: 2c836bc53feb12f70a07dacaa6256d4d66624f38
+GitCommit: d220bea42308935d3bee1b40701f39e8c0d69860
 Directory: stable
 
 Tags: stable-slim
 GitFetch: refs/heads/dist-stable
-GitCommit: 2c836bc53feb12f70a07dacaa6256d4d66624f38
+GitCommit: d220bea42308935d3bee1b40701f39e8c0d69860
 Directory: stable/slim
 
 Tags: stable-backports
 GitFetch: refs/heads/dist-stable
-GitCommit: 2c836bc53feb12f70a07dacaa6256d4d66624f38
+GitCommit: d220bea42308935d3bee1b40701f39e8c0d69860
 Directory: stable/backports
 
 Tags: stretch
@@ -98,17 +98,17 @@ Directory: unstable/slim
 
 Tags: 7.11, 7, wheezy
 GitFetch: refs/heads/dist-oldstable
-GitCommit: 1626bb6698f1cab6e7529a4238717270699a8246
+GitCommit: a7561bee7a4bbc2e5f7ea6b8a7377d8abe6eb2a6
 Directory: wheezy
 
 Tags: wheezy-slim
 GitFetch: refs/heads/dist-oldstable
-GitCommit: 1626bb6698f1cab6e7529a4238717270699a8246
+GitCommit: a7561bee7a4bbc2e5f7ea6b8a7377d8abe6eb2a6
 Directory: wheezy/slim
 
 Tags: wheezy-backports
 GitFetch: refs/heads/dist-oldstable
-GitCommit: 1626bb6698f1cab6e7529a4238717270699a8246
+GitCommit: a7561bee7a4bbc2e5f7ea6b8a7377d8abe6eb2a6
 Directory: wheezy/backports
 
 # sid + rc-buggy


### PR DESCRIPTION
See also https://security-tracker.debian.org/tracker/CVE-2016-1252, https://lists.debian.org/debian-security-announce/2016/msg00316.html, and https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1647467.

(unstable is updated, but hasn't hit the CDN yet and testing will be subject to a short migration delay, so those suites are not included in this update yet)