### PR TITLE
Updated Python manifest for Python Alpine

### DIFF
--- a/library/python
+++ b/library/python
@@ -13,7 +13,7 @@ GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
 Directory: 2.7/slim
 
 Tags: 2.7.13-alpine, 2.7-alpine, 2-alpine
-GitCommit: a248f4583c5f788e1af02016f762cdc323ee5765
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 2.7/alpine
 
 Tags: 2.7.13-wheezy, 2.7-wheezy, 2-wheezy
@@ -38,7 +38,7 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.3/slim
 
 Tags: 3.3.6-alpine, 3.3-alpine
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 3.3/alpine
 
 Tags: 3.3.6-wheezy, 3.3-wheezy
@@ -58,7 +58,7 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.4/slim
 
 Tags: 3.4.5-alpine, 3.4-alpine
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 3.4/alpine
 
 Tags: 3.4.5-wheezy, 3.4-wheezy
@@ -78,7 +78,7 @@ GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
 Directory: 3.5/slim
 
 Tags: 3.5.2-alpine, 3.5-alpine
-GitCommit: 693a75332e8ae5ad3bfae6e8399c4d7cc3cb6181
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 3.5/alpine
 
 Tags: 3.5.2-onbuild, 3.5-onbuild
@@ -99,7 +99,7 @@ GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
 Directory: 3.6/slim
 
 Tags: 3.6.0-alpine, 3.6-alpine, 3-alpine, alpine
-GitCommit: 7eca63adca38729424a9bab957f006f5caad870f
+GitCommit: 6db43ca0155da8cafdd9001b1bebc8a08052c2bf
 Directory: 3.6/alpine
 
 Tags: 3.6.0-onbuild, 3.6-onbuild, 3-onbuild, onbuild


### PR DESCRIPTION
Re-generated manifest to include changes made for Alpine versions of Python package (i.e. use alpine 3.5)